### PR TITLE
Use either older or newer pwkit modules (casautil, etc)

### DIFF
--- a/rtpipe/RT.py
+++ b/rtpipe/RT.py
@@ -8,7 +8,11 @@ from contextlib import closing
 import numpy as n
 from scipy.special import erf
 import scipy.stats.mstats as mstats
-import casautil, os, pickle, glob, time
+try:
+    import casautil 
+except ImportError:
+    import pwkit.environments.casa.util as casautil
+import os, pickle, glob, time
 import logging
 from functools import partial
 

--- a/rtpipe/calpipe.py
+++ b/rtpipe/calpipe.py
@@ -1,4 +1,7 @@
-import tasklib as tl
+try:
+    import tasklib as tl
+except ImportError:
+    import pwkit.environments.casa.tasks as tl
 import rtpipe.parsesdm as ps
 import os, string, glob
 import sdmreader, sdmpy

--- a/rtpipe/parsecal.py
+++ b/rtpipe/parsecal.py
@@ -1,6 +1,9 @@
 import numpy as n
 import os, glob, sys
-import casautil
+try:
+    import casautil
+except ImportError:
+    import pwkit.environments.casa.util as casautil
 import logging, logging.config
 
 # set up

--- a/rtpipe/parsems.py
+++ b/rtpipe/parsems.py
@@ -1,4 +1,7 @@
-import casautil
+try:
+    import casautil
+except ImportError:
+    import pwkit.environments.casa.util as casautil
 import os, pickle, time, string
 import numpy as n
 import rtpipe.parseparams as pp

--- a/rtpipe/parsesdm.py
+++ b/rtpipe/parsesdm.py
@@ -7,7 +7,11 @@ import logging
 logger = logging.getLogger(__name__)
 import numpy as n
 import os, shutil, subprocess, glob, string
-import casautil, tasklib
+try:
+    import casautil, tasklib
+except ImportError:
+    import pwkit.environments.casa.tasks as tasklib
+    import pwkit.environments.casa.util as casautil
 import sdmreader, sdmpy
 import rtpipe.parseparams as pp
 qa = casautil.tools.quanta()


### PR DESCRIPTION
First tries to import casautil, if that doesn't work tries pwkit.environments.casa.util instead.